### PR TITLE
Initial ARM-mode CPU implementation

### DIFF
--- a/cpu/src/instruction_type.rs
+++ b/cpu/src/instruction_type.rs
@@ -1,8 +1,8 @@
 // https://www.ecs.csun.edu/~smirzaei/docs/ece425/arm7tdmi_instruction_set_reference.pdf page 1
 #[derive(Debug)]
 pub enum InstructionType {
-    MultiplyAccumulate,
-    MultiplyAccumulateLong,
+    Multiply,
+    MultiplyLong,
     BranchExchange,
     SingleSwap,
     HalfwordTransferReg,
@@ -25,9 +25,9 @@ impl InstructionType {
         let lo_4 = lo_8 & 0xF;
 
         if (hi_8 | 0b11 == 0b00000011) && (lo_4 == 0b1001) {
-            Self::MultiplyAccumulate
+            Self::Multiply
         } else if (hi_8 | 0b111 == 0b00001111) && (lo_4 == 0b1001) {
-            Self::MultiplyAccumulateLong
+            Self::MultiplyLong
         } else if (encoding >> 4) & 0xFFFFFF == 0x12fff1 {
             Self::BranchExchange
         } else if (hi_8 | 0b100 == 0b00010100) && (lo_8 == 0b00001001) {

--- a/cpu/src/instruction_type.rs
+++ b/cpu/src/instruction_type.rs
@@ -7,9 +7,8 @@ pub enum InstructionType {
     SingleSwap,
     HalfwordTransferReg,
     HalfwordTransferImm,
-    SignedTransfer,
+    SingleTransfer,
     DataProcessing,
-    LoadStore,
     Undefined,
     BlockTransfer,
     Branch,
@@ -37,15 +36,13 @@ impl InstructionType {
             Self::HalfwordTransferReg
         } else if (hi_8 | 0b11011 == 0b00011111) && (lo_4 == 0b1011) {
             Self::HalfwordTransferImm
-        } else if (hi_8 | 0b11111 == 0b00011111) && (lo_4 | 0b0010 == 0b1111) {
-            Self::SignedTransfer
         } else if hi_8 | 0b111111 == 0b00111111 {
             Self::DataProcessing
         } else if hi_8 | 0b111111 == 0b01111111 {
             if (encoding >> 25) & 1 == 1 && (encoding >> 4) & 1 == 1 {
                 Self::Undefined
             } else {
-                Self::LoadStore
+                Self::SingleTransfer
             }
         } else if hi_8 | 0b11011 == 0b10011011 {
             Self::BlockTransfer

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -93,7 +93,7 @@ impl CPU {
                 }
                 InstructionType::SingleTransfer => self.single_transfer_instr(encoding),
                 InstructionType::DataProcessing => self.data_proc_instr(encoding),
-                InstructionType::Undefined => println!("Undefined instruction {:8X}", encoding), // TODO: Do trap
+                InstructionType::Undefined => self.undefined_interrupt(),
                 InstructionType::BlockTransfer => self.block_transfer(encoding),
                 InstructionType::Branch => self.branch_instr(encoding),
                 InstructionType::CoprocDataTransfer => {}
@@ -588,6 +588,15 @@ impl CPU {
         self.cpsr.set_t(false);
         self.cpsr.set_i(true);
         self.set_register(15, SWI_VEC);
+    }
+
+    fn undefined_interrupt(&mut self) {
+        self.und_register_bank[1] = self.get_register(15).wrapping_add(4);
+        self.und_spsr.raw = self.cpsr.raw;
+        self.cpsr.set_mode(OperatingMode::Undefined);
+        self.cpsr.set_t(false);
+        self.cpsr.set_i(true);
+        self.set_register(15, UND_VEC);
     }
 
     // Decodes a 12-bit operand to a register shifted by an immediate- or register-defined value

--- a/cpu/src/operating_mode.rs
+++ b/cpu/src/operating_mode.rs
@@ -1,12 +1,12 @@
 #[derive(PartialEq)]
 pub enum OperatingMode {
-    User,
-    FastInterrupt,
-    Interrupt,
-    Supervisor,
-    Abort,
-    System,
-    Undefined,
+    User = 0b10000,
+    FastInterrupt = 0b10001,
+    Interrupt = 0b10010,
+    Supervisor = 0b10011,
+    Abort = 0b10111,
+    System = 0b11111,
+    Undefined = 0b11011,
 }
 
 impl OperatingMode {

--- a/cpu/src/status_register.rs
+++ b/cpu/src/status_register.rs
@@ -67,6 +67,11 @@ impl StatusRegister {
         self.set_bit(5, val)
     }
 
+    pub fn set_mode(&mut self, mode: OperatingMode) {
+        self.raw &= !0b11111;
+        self.raw |= mode as u32;
+    }
+
     pub fn get_mode(&self) -> OperatingMode {
         OperatingMode::from_u32(self.raw & 0b11111).expect("Invalid operating mode")
     }


### PR DESCRIPTION
This PR implements all ARM7TDMI instructions, excluding coprocessor instructions and (crucially) Thumb mode instructions.

### TODO
- Thumb instructions (including decoding the PC differently for halfword-alignment)
- More accurate instruction pipeline, as currently everything is executed in one cycle
- Several inaccuracies in instructions
- Lots of tests, in particular once the pipeline is working