### PR TITLE
Initial workable CPU implementation

### DIFF
--- a/cpu/src/instruction_type.rs
+++ b/cpu/src/instruction_type.rs
@@ -223,7 +223,7 @@ impl InstructionType {
                 let pop_flag = (encoding >> 11) & 1;
                 let lr_flag = (encoding >> 8) & 1;
                 let reg_list = encoding & 0xFF;
-                let hi_8 = if pop_flag == 0 {
+                let hi_8 = if pop_flag == 1 {
                     0b10001011
                 } else {
                     0b10010010

--- a/cpu/src/instruction_type.rs
+++ b/cpu/src/instruction_type.rs
@@ -62,4 +62,148 @@ impl InstructionType {
             Self::Undefined
         }
     }
+
+    // Translates a Thumb encoding to an equivalent ARM encoding
+    // Returns (instruction_type, TODO)
+    pub fn from_thumb_encoding(thumb_encoding: u16) -> Self {
+        let mut allow_update_flags = true;
+
+        // TODO: Some of these don't update flags!
+        let encoding = thumb_encoding as u32;
+        let hi_n = |n: usize| (encoding >> (16 - n)) & ((1 << n) - 1);
+        if hi_n(3) == 0b000 && (encoding >> 11) & 0b11 != 0b11 {
+            // Shift by immediate
+            let immed_5 = (encoding >> 6) & 0b11111;
+            let rm = (encoding >> 3) & 0b111;
+            let rd = encoding & 0b111;
+            let shift_type = (encoding >> 11) ^ 0b11;
+            // MOVS <Rd>, <Rm>, <shift_type> #<immed_5>
+            (0b1110000110110000 << 16) | (rd << 12) | (immed_5 << 7) | (shift_type << 5) | rm
+        } else if hi_n(6) == 0b000110 {
+            // Add/subtract register
+            let op = (encoding >> 9) & 1;
+            let rm = (encoding >> 6) & 0b111;
+            let rn = (encoding >> 3) & 0b111;
+            let rd = encoding & 0b111;
+            // ADDS/SUBS <Rd>, <Rn>, <Rm>
+            (0b111000000001 << 20) | (1 << (22 + op)) | (rn << 16) | (rd << 12) | rm
+        } else if hi_n(6) == 0b000111 {
+            // Add/subtract immediate
+            let op = (encoding >> 9) & 1;
+            let immed_3 = (encoding >> 6) & 0b111;
+            let rn = (encoding >> 3) & 0b111;
+            let rd = encoding & 0b111;
+            // ADDS/SUBS <Rd>, <Rn>, #<immed_3>
+            (0b111000100001 << 20) | (1 << (23 - op)) | (rn << 16) | (rd << 12) | immed_3
+        } else if hi_n(3) == 0b001 {
+            // Add/subtract/compare/move immediate
+            let reg = (encoding >> 8) & 0b111;
+            let immed_8 = encoding & 0xFF;
+            let op = match (encoding >> 11) & 0b11 {
+                0b00 => 0b1101,     // MOV
+                0b01 => 0b1010,     // CMP
+                0b10 => 0b0100,     // ADD
+                0b11 | _ => 0b0010, // SUB
+            };
+            // ADDS/SUBS/MOVS/CMP <Rd>|<Rn>, #<8_bit_immed>
+            (0b111000100001 << 20) | (op << 21) | (reg << 16) | (reg << 12) | immed_8
+        } else if hi_n(6) == 0b010000 {
+            // Data-processing register
+            let op = (encoding >> 6) & 0b1111;
+            let rm_rs = (encoding >> 3) & 0b111;
+            let rd_rn = encoding & 0b111;
+            // The bottom 7 nybbles
+            let (a, b, c, d, e, f, g) = match op {
+                0b0000 => (0b0000, 0b0001, rd_rn, rd_rn, 0, 0, rm_rs), // AND
+                0b0001 => (0b0000, 0b0011, rd_rn, rd_rn, 0, 0, rm_rs), // EOR
+                0b0010 => (0b0001, 0b1011, 0, rd_rn, rm_rs, 1, rd_rn), // LSL
+                0b0011 => (0b0001, 0b1011, 0, rd_rn, rm_rs, 3, rd_rn), // LSR
+                0b0100 => (0b0001, 0b1011, 0, rd_rn, rm_rs, 5, rd_rn), // ASR
+                0b0101 => (0b0000, 0b1011, rd_rn, rd_rn, 0, 0, rm_rs), // ADC
+                0b0110 => (0b0000, 0b1101, rd_rn, rd_rn, 0, 0, rm_rs), // SBC
+                0b0111 => (0b0001, 0b1011, 0, rd_rn, rm_rs, 7, rd_rn), // ROR
+                0b1000 => (0b0001, 0b0001, rd_rn, 0, 0, 0, rm_rs),     // TST
+                0b1001 => (0b0010, 0b0111, rm_rs, rd_rn, 0, 0, 0),     // NEG
+                0b1010 => (0b0001, 0b0101, rd_rn, 0, 0, 0, rm_rs),     // CMP
+                0b1011 => (0b0001, 0b0111, rd_rn, 0, 0, 0, rm_rs),     // CMN
+                0b1100 => (0b0001, 0b1001, rd_rn, rd_rn, 0, 0, rm_rs), // ORR
+                0b1101 => (0b0000, 0b0001, rd_rn, 0, rd_rn, 9, rm_rs), // MUL
+                0b1110 => (0b0001, 0b1101, rd_rn, rd_rn, 0, 0, rm_rs), // BIC
+                0b1111 | _ => (0b0001, 0b1111, 0, rd_rn, 0, 0, rm_rs), // MVN
+            };
+            (0b1110 << 28) | (a << 24) | (b << 20) | (c << 16) | (d << 12) | (e << 8) | (f << 4) | g
+        } else if hi_n(6) == 0b010001 && (encoding >> 8) & 0b11 != 0b11 {
+            // Special data processing
+            let op = (encoding >> 8) & 0b11;
+            let rm = (encoding >> 3) & 0b1111; // (H2 << 3) | Rm
+            let rd_rn = (((encoding >> 7) & 1) << 3) | encoding & 0b111; // (H1 << 3) | (Rd or Rn)
+            match op {
+                0b00 => (0b111000001000 << 20) | (rd_rn << 16) | (rd_rn << 12) | rm,
+                0b01 => (0b111000001001 << 20) | (rd_rn << 16) | rm,
+                0b10 | _ => (0b111000011010 << 20) | (rd_rn << 12) | rm,
+            }
+        } else if hi_n(8) == 0b01000111 {
+            // Branch/exchange instruction set
+            let link = (encoding >> 7) & 1 == 1;
+            let reg = (encoding >> 3) & 0b1111;
+            // TODO: BX behaves differently when with reg=15
+            (0b1110000100101111111111110001 << 4) | (link << 5) | reg
+        } else if hi_n(5) == 0b01001 {
+            // Load from literal pool
+            let immed_8 = encoding & 0xFF;
+            let reg = (encoding >> 8) & 0b111;
+            // LDR <Rd>, [PC, #<immed_8> * 4]
+            (0b1110010110011111 << 16) | (reg << 12) | (immed_8 << 2)
+        } else if hi_n(4) == 0b0101 {
+            // Load/store register offset
+            let op = (encoding >> 9) & 0b111;
+            let rm = (encoding >> 6) & 0b111;
+            let rn = (encoding >> 3) & 0b111;
+            let rd = encoding & 0b111;
+            let (hi_8, lo_4) = match op {
+                0b000 => (0b01111000, 0b0000), // STR
+                0b001 => (0b00011000, 0b1011), // STRH
+                0b010 => (0b01111100, 0b0000), // STRB
+                0b011 => (0b00011001, 0b1101), // LDRSB
+                0b100 => (0b01111001, 0b0000), // LDR
+                0b101 => (0b00011001, 0b1011), // LDRH
+                0b110 => (0b01111101, 0b0000), // LDRB
+                0b111 => (0b00011001, 0b1111), // LDRSH
+            };
+            (0b1110 << 28) | (hi_8 << 20) | (rn << 16) | (rd << 12) | (lo_4 << 4) | rm
+        } else if hi_n(3) == 0b011 {
+            // Load/store word/byte immediate offset
+            let byte = (encoding >> 12) & 1;
+            let load = (encoding >> 11) & 1;
+            let offset = (encoding >> 6) & 0b11111;
+            let rn = (encoding >> 3) & 0b111;
+            let rd = encoding & 0b111;
+            (0b111001011 << 23) | (load << 20) | (byte << 22) | (rn << 16) | (rd << 12) | offset
+        } else if hi_n(4) == 0b1000 {
+            // Load/store halfword immediate offset
+        } else if hi_n(4) == 0b1001 {
+            // Load/store to/from stack
+        } else if hi_n(4) == 0b1010 {
+            // Add to SP or PC
+        } else if hi_n(4) == 0b1011 {
+            // Miscellaneous
+        } else if hi_n(4) == 0b1100 {
+            // Load/store multiple
+        } else if hi_n(4) == 0b1101 && (encoding >> 9) & 0b111 != 0b111 {
+            // Conditional branch
+        } else if hi_n(8) == 0b11011110 {
+            // Undefined instruction
+        } else if hi_n(8) == 0b11011111 {
+            // Software interrupt
+        } else if hi_n(5) == 0b11100 {
+            // Unconditional branch
+        } else if hi_n(5) == 0b11101 {
+            // Undefined instruction prior to ARMv5
+        } else if hi_n(5) == 0b11110 {
+            // BL/BLX prefix
+        } else if hi_n(5) == 0b11111 {
+            // BL suffix
+        }
+        Self::Undefined // TODO: Remove!
+    }
 }

--- a/cpu/src/instruction_type.rs
+++ b/cpu/src/instruction_type.rs
@@ -81,7 +81,7 @@ impl InstructionType {
             let immed_5 = (encoding >> 6) & 0b11111;
             let rm = (encoding >> 3) & 0b111;
             let rd = encoding & 0b111;
-            let shift_type = (encoding >> 11) ^ 0b11;
+            let shift_type = (encoding >> 11) & 0b11;
             // MOVS <Rd>, <Rm>, <shift_type> #<immed_5>
             (0b1110000110110000 << 16) | (rd << 12) | (immed_5 << 7) | (shift_type << 5) | rm
         } else if hi_n(6) == 0b000110 {
@@ -91,7 +91,7 @@ impl InstructionType {
             let rn = (encoding >> 3) & 0b111;
             let rd = encoding & 0b111;
             // ADDS/SUBS <Rd>, <Rn>, <Rm>
-            (0b111000000001 << 20) | (1 << (22 + op)) | (rn << 16) | (rd << 12) | rm
+            (0b111000000001 << 20) | (1 << (23 - op)) | (rn << 16) | (rd << 12) | rm
         } else if hi_n(6) == 0b000111 {
             // Add/subtract immediate
             let op = (encoding >> 9) & 1;
@@ -104,14 +104,14 @@ impl InstructionType {
             // Add/subtract/compare/move immediate
             let reg = (encoding >> 8) & 0b111;
             let immed_8 = encoding & 0xFF;
-            let op = match (encoding >> 11) & 0b11 {
-                0b00 => 0b1101,     // MOV
-                0b01 => 0b1010,     // CMP
-                0b10 => 0b0100,     // ADD
-                0b11 | _ => 0b0010, // SUB
+            let (op, a, b) = match (encoding >> 11) & 0b11 {
+                0b00 => (0b1101, 0, reg),       // MOV
+                0b01 => (0b1010, reg, 0),       // CMP
+                0b10 => (0b0100, reg, reg),     // ADD
+                0b11 | _ => (0b0010, reg, reg), // SUB
             };
             // ADDS/SUBS/MOVS/CMP <Rd>|<Rn>, #<8_bit_immed>
-            (0b111000100001 << 20) | (op << 21) | (reg << 16) | (reg << 12) | immed_8
+            (0b111000100001 << 20) | (op << 21) | (a << 16) | (b << 12) | immed_8
         } else if hi_n(6) == 0b010000 {
             // Data-processing register
             let op = (encoding >> 6) & 0b1111;

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -634,6 +634,7 @@ impl CPU {
             self.set_register(14, self.get_register(15));
         }
 
+        // TODO: Branch must use a different shift in thumb mode
         let mut offset = (encoding & 0xFFFFFF) << 2; // 24 bits, shifted left
         if (offset >> 23) & 1 == 1 {
             offset |= 0xFF_000000; // Sign extend

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -135,14 +135,14 @@ impl CPU {
         if n == 13 || n == 14 {
             match mode {
                 OperatingMode::User | OperatingMode::System => self.registers[n],
-                OperatingMode::FastInterrupt => self.fiq_register_bank[n],
-                OperatingMode::Interrupt => self.irq_register_bank[n],
-                OperatingMode::Supervisor => self.svc_register_bank[n],
-                OperatingMode::Abort => self.abt_register_bank[n],
-                OperatingMode::Undefined => self.und_register_bank[n],
+                OperatingMode::FastInterrupt => self.fiq_register_bank[n - 8],
+                OperatingMode::Interrupt => self.irq_register_bank[n - 13],
+                OperatingMode::Supervisor => self.svc_register_bank[n - 13],
+                OperatingMode::Abort => self.abt_register_bank[n - 13],
+                OperatingMode::Undefined => self.und_register_bank[n - 13],
             }
         } else if mode == OperatingMode::FastInterrupt && n >= 8 && n <= 14 {
-            self.fiq_register_bank[n]
+            self.fiq_register_bank[n - 8]
         } else {
             self.registers[n]
         }
@@ -153,14 +153,14 @@ impl CPU {
         if n == 13 || n == 14 {
             match mode {
                 OperatingMode::User | OperatingMode::System => self.registers[n] = val,
-                OperatingMode::FastInterrupt => self.fiq_register_bank[n] = val,
-                OperatingMode::Interrupt => self.irq_register_bank[n] = val,
-                OperatingMode::Supervisor => self.svc_register_bank[n] = val,
-                OperatingMode::Abort => self.abt_register_bank[n] = val,
-                OperatingMode::Undefined => self.und_register_bank[n] = val,
+                OperatingMode::FastInterrupt => self.fiq_register_bank[n - 8] = val,
+                OperatingMode::Interrupt => self.irq_register_bank[n - 13] = val,
+                OperatingMode::Supervisor => self.svc_register_bank[n - 13] = val,
+                OperatingMode::Abort => self.abt_register_bank[n - 13] = val,
+                OperatingMode::Undefined => self.und_register_bank[n - 13] = val,
             }
         } else if mode == OperatingMode::FastInterrupt && n >= 8 && n <= 14 {
-            self.fiq_register_bank[n] = val
+            self.fiq_register_bank[n - 8] = val
         } else {
             self.registers[n] = val
         }

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -47,6 +47,6 @@ pub trait Memory {
         let hi = (data >> 16) as u16;
         let lo = (data & 0xffff) as u16;
         self.write_u16(addr, lo);
-        self.write_u16(addr + 1, hi);
+        self.write_u16(addr + 2, hi);
     }
 }

--- a/memory/src/ram.rs
+++ b/memory/src/ram.rs
@@ -1,13 +1,13 @@
 use crate::Memory;
 
 pub struct RAM<const LENGTH: usize> {
-    memory: [u8; LENGTH],
+    memory: Vec<u8>,
 }
 
 impl<const LENGTH: usize> RAM<LENGTH> {
     pub fn new() -> Self {
         Self {
-            memory: [0; LENGTH],
+            memory: vec![0; LENGTH],
         }
     }
 }

--- a/memory/src/rom.rs
+++ b/memory/src/rom.rs
@@ -12,7 +12,8 @@ impl<const LENGTH: usize> ROM<LENGTH> {
     }
 
     pub fn flash(&mut self, data: Vec<u8>) {
-        self.memory = data;
+        self.memory = vec![0; LENGTH];
+        self.memory[..data.len()].clone_from_slice(&data);
     }
 }
 

--- a/memory/src/rom.rs
+++ b/memory/src/rom.rs
@@ -1,17 +1,17 @@
 use crate::Memory;
 
 pub struct ROM<const LENGTH: usize> {
-    memory: [u8; LENGTH],
+    memory: Vec<u8>,
 }
 
 impl<const LENGTH: usize> ROM<LENGTH> {
     pub fn new() -> Self {
         Self {
-            memory: [0; LENGTH],
+            memory: vec![0; LENGTH],
         }
     }
 
-    pub fn flash(&mut self, data: [u8; LENGTH]) {
+    pub fn flash(&mut self, data: Vec<u8>) {
         self.memory = data;
     }
 }


### PR DESCRIPTION
- All ARMv4T Thumb instructions implemented
    - Some minor details still need to be made more accurate, e.g. some instructions shouldn't set flags
    - The vast majority of Thumb instructions translate into equivalent ARM instructions
        - As per [this document](https://documentation-service.arm.com/static/5f8dacc8f86e16515cdb865a?token=)
        - The branch instruction pair has no direct ARM equivalent, so it decodes to a new instruction type
    - Added some exceptions and abstractions that largely account for the idiosyncrasies of Thumb (e.g. instruction width)
- Fixed a number of bugs
    - An indexing bug made register fetches fail for some modes
    - `write_u32` had a typo that caused out-of-range accesses