### PR TITLE
Initial sound implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "cpu",
     "ppu",
+    "sound",
     "memory",
     "gba",
 ]

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -974,8 +974,11 @@ impl Memory for CPU {
             0x03000000..=0x03FFFFFF => self.iwram[(addr - 0x03000000) % 0x8000],
             // 0x03FFFF00..=0x03FFFFFF => self.iwram[addr - 0x3FF8000],
             // TODO: Different wait states
+            0x09FFFF00..=0x09FFFFFF => 1,
             0x08000000..=0x09FFFFFF => self.cart_rom[addr - 0x08000000],
             0x0A000000..=0x0BFFFFFF => self.cart_rom[addr - 0x0A000000],
+            // 0x0D000000..=0x0DFFFFFF => 1,
+            0x0D000000..=0x0DFFFFFF => 1,
             0x0C000000..=0x0DFFFFFF => self.cart_rom[addr - 0x0C000000],
             // Flash stub
             0x0E000000 => 0xC2,
@@ -997,6 +1000,7 @@ impl Memory for CPU {
             // 0x03000000..=0x0307FFFF => self.iwram[addr - 0x03000000] = data,
             0x03000000..=0x03FFFFFF => self.iwram[(addr - 0x03000000) % 0x8000] = data,
             // 0x03FFFF00..=0x03FFFFFF => self.iwram[addr - 0x3FF8000] = data,
+            // 0x0D000000..=0x0DFFFFFF => println!("{:08X} {:02X}", addr, data),
             0x08000000..=0x0DFFFFFF => {}
             // 0x08000000..=0x09FFFFFF => self.cart_rom[addr - 0x08000000] = data,
             // 0x0A000000..=0x0BFFFFFF => self.cart_rom[addr - 0x0A000000] = data,

--- a/gba/Cargo.toml
+++ b/gba/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 cpu = { path = "../cpu" }
 ppu = { path = "../ppu" }
+sound = { path = "../sound" }
 memory = { path = "../memory" }
 bitfield = "0.13.2"
 sdl2 = "0.34.3"

--- a/gba/src/dma_controller.rs
+++ b/gba/src/dma_controller.rs
@@ -80,7 +80,6 @@ impl DmaController {
                 }
                 if (channel == 1 || channel == 2) && (active_transfer.0.start_timing() == 0b11) {
                     n_units = 4;
-                    println!("Sound DMA {channel}: {:x?}", active_transfer);
                 }
                 for _ in 0..n_units {
                     let mut unit_size = if active_transfer.0.unit_size() { 4 } else { 2 };

--- a/gba/src/lib.rs
+++ b/gba/src/lib.rs
@@ -14,18 +14,23 @@ use crate::timer_controller::TimerController;
 use cpu::CPU;
 use memory::{Memory, RAM};
 use ppu::PPU;
+use sound::{AudioRingBuffer, SoundController};
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 pub struct GBA {
     cpu: Rc<RefCell<CPU>>,
     ppu: Rc<RefCell<PPU>>,
 
+    sound_controller: Rc<RefCell<SoundController>>,
     key_controller: Rc<RefCell<KeyController>>,
     dma_controller: Rc<RefCell<DmaController>>,
     timer_controller: Rc<RefCell<TimerController>>,
     interrupt_controller: Rc<RefCell<InterruptController>>,
+
+    audio_buffer: Arc<Mutex<AudioRingBuffer>>,
 }
 
 impl GBA {
@@ -40,6 +45,9 @@ impl GBA {
             oam.clone(),
         )));
 
+        let audio_buffer = Arc::new(Mutex::new(AudioRingBuffer::new()));
+
+        let sound_controller = Rc::new(RefCell::new(SoundController::new(audio_buffer.clone())));
         let key_controller = Rc::new(RefCell::new(KeyController::new()));
         let dma_controller = Rc::new(RefCell::new(DmaController::new()));
         let timer_controller = Rc::new(RefCell::new(TimerController::new()));
@@ -50,6 +58,7 @@ impl GBA {
             palette_ram: palette_ram.clone(),
             oam: oam.clone(),
             ppu: ppu.clone(),
+            sound_controller: sound_controller.clone(),
             key_controller: key_controller.clone(),
             dma_controller: dma_controller.clone(),
             timer_controller: timer_controller.clone(),
@@ -61,10 +70,12 @@ impl GBA {
         Self {
             cpu,
             ppu,
+            sound_controller,
             key_controller,
             dma_controller,
             timer_controller,
             interrupt_controller,
+            audio_buffer,
         }
     }
 
@@ -104,7 +115,7 @@ impl GBA {
                     .request(interrupt_controller::IRQ_VCOUNTER);
             }
 
-            // TODO: Tick APU
+            self.sound_controller.borrow_mut().tick();
             self.timer_controller
                 .borrow_mut()
                 .tick(self.interrupt_controller.clone());
@@ -119,6 +130,10 @@ impl GBA {
 
     pub fn try_get_framebuffer(&mut self) -> Option<[u8; 240 * 160 * 2]> {
         self.ppu.borrow_mut().try_get_framebuffer()
+    }
+
+    pub fn get_audio_buffer(&self) -> Arc<Mutex<AudioRingBuffer>> {
+        self.audio_buffer.clone()
     }
 
     pub fn flash_bios(&mut self, data: Vec<u8>) {
@@ -141,6 +156,7 @@ struct MemoryMap {
     oam: Rc<RefCell<RAM<0x400>>>,         // Object attribute memory
 
     ppu: Rc<RefCell<PPU>>,
+    sound_controller: Rc<RefCell<SoundController>>,
     key_controller: Rc<RefCell<KeyController>>,
     dma_controller: Rc<RefCell<DmaController>>,
     timer_controller: Rc<RefCell<TimerController>>,
@@ -159,10 +175,7 @@ impl Memory for MemoryMap {
 
             // IO map
             0x04000000..=0x04000057 => self.ppu.borrow().peek(addr - 0x04000000),
-            0x04000060..=0x040000A8 => {
-                // TODO: Sound
-                0
-            }
+            0x04000060..=0x040000A8 => self.sound_controller.borrow().peek(addr - 0x04000000),
             0x040000B0..=0x040000E1 => self.dma_controller.borrow().peek(addr - 0x04000000),
             0x04000100..=0x04000111 => self.timer_controller.borrow().peek(addr - 0x04000000),
             0x04000130..=0x04000133 => self.key_controller.borrow().peek(addr - 0x04000000),
@@ -188,9 +201,10 @@ impl Memory for MemoryMap {
 
             // IO map
             0x04000000..=0x04000057 => self.ppu.borrow_mut().write(addr - 0x04000000, data),
-            0x04000060..=0x040000A8 => {
-                // TODO: Sound
-            }
+            0x04000060..=0x040000A8 => self
+                .sound_controller
+                .borrow_mut()
+                .write(addr - 0x04000000, data),
             0x040000B0..=0x040000E1 => self
                 .dma_controller
                 .borrow_mut()

--- a/gba/src/lib.rs
+++ b/gba/src/lib.rs
@@ -77,38 +77,41 @@ impl GBA {
             self.cpu.borrow_mut().tick();
         }
 
-        let (vblank, hblank, vblank_irq, hblank_irq, vcounter_irq) = self.ppu.borrow_mut().tick();
+        for _ in 0..3 {
+            let (vblank, hblank, vblank_irq, hblank_irq, vcounter_irq) =
+                self.ppu.borrow_mut().tick();
 
-        if vblank {
-            self.dma_controller.borrow_mut().on_vblank();
-        }
-        if hblank {
-            self.dma_controller.borrow_mut().on_hblank();
-        }
+            if vblank {
+                self.dma_controller.borrow_mut().on_vblank();
+            }
+            if hblank {
+                self.dma_controller.borrow_mut().on_hblank();
+            }
 
-        if vblank_irq {
-            self.interrupt_controller
-                .borrow_mut()
-                .request(interrupt_controller::IRQ_VBLANK);
-        }
-        if hblank_irq {
-            self.interrupt_controller
-                .borrow_mut()
-                .request(interrupt_controller::IRQ_HBLANK);
-        }
-        if vcounter_irq {
-            self.interrupt_controller
-                .borrow_mut()
-                .request(interrupt_controller::IRQ_VCOUNTER);
-        }
+            if vblank_irq {
+                self.interrupt_controller
+                    .borrow_mut()
+                    .request(interrupt_controller::IRQ_VBLANK);
+            }
+            if hblank_irq {
+                self.interrupt_controller
+                    .borrow_mut()
+                    .request(interrupt_controller::IRQ_HBLANK);
+            }
+            if vcounter_irq {
+                self.interrupt_controller
+                    .borrow_mut()
+                    .request(interrupt_controller::IRQ_VCOUNTER);
+            }
 
-        // TODO: Tick APU
-        self.timer_controller
-            .borrow_mut()
-            .tick(self.interrupt_controller.clone());
-        self.dma_controller
-            .borrow_mut()
-            .tick(self.cpu.clone(), self.interrupt_controller.clone());
+            // TODO: Tick APU
+            self.timer_controller
+                .borrow_mut()
+                .tick(self.interrupt_controller.clone());
+            self.dma_controller
+                .borrow_mut()
+                .tick(self.cpu.clone(), self.interrupt_controller.clone());
+        }
 
         // TODO: When a frame is ready, the GBA should expose the framebuffer,
         // TODO: and the frontend can read it AND THEN update keypad state

--- a/gba/src/lib.rs
+++ b/gba/src/lib.rs
@@ -115,10 +115,15 @@ impl GBA {
                     .request(interrupt_controller::IRQ_VCOUNTER);
             }
 
-            self.sound_controller.borrow_mut().tick();
-            self.timer_controller
-                .borrow_mut()
-                .tick(self.interrupt_controller.clone());
+            let sound_dma_requested = self.sound_controller.borrow_mut().tick();
+            if sound_dma_requested {
+                // println!("Bla");
+                self.dma_controller.borrow_mut().on_dma_sound_request();
+            }
+            self.timer_controller.borrow_mut().tick(
+                self.interrupt_controller.clone(),
+                self.sound_controller.clone(),
+            );
             self.dma_controller
                 .borrow_mut()
                 .tick(self.cpu.clone(), self.interrupt_controller.clone());

--- a/gba/src/lib.rs
+++ b/gba/src/lib.rs
@@ -88,6 +88,9 @@ impl GBA {
             self.cpu.borrow_mut().tick();
         }
 
+        // TODO: This loop is an artificial and highly imperfect compensation for the lack of CPU
+        // pipeline emulation. The imperfect timing breaks some visuals (like the 3D effect in
+        // Monkey Ball Jr., I believe) and leads to sound desync.
         for _ in 0..3 {
             let (vblank, hblank, vblank_irq, hblank_irq, vcounter_irq) =
                 self.ppu.borrow_mut().tick();
@@ -117,7 +120,6 @@ impl GBA {
 
             let sound_dma_requested = self.sound_controller.borrow_mut().tick();
             if sound_dma_requested {
-                // println!("Bla");
                 self.dma_controller.borrow_mut().on_dma_sound_request();
             }
             self.timer_controller.borrow_mut().tick(

--- a/gba/src/main.rs
+++ b/gba/src/main.rs
@@ -40,6 +40,13 @@ impl AudioCallback for AudioBufferWrapper {
             let play_i = audio_buffer.play_cursor & (audio_buffer.buffer.len() - 1);
             *x = audio_buffer.buffer[play_i];
             audio_buffer.play_cursor += 1;
+            // audio_buffer.play_cursor = (audio_buffer.play_cursor as i64
+            //     + (((audio_buffer.write_cursor as i64 - audio_buffer.play_cursor as i64) >> 8)
+            //         & !1)) as usize;
+            println!(
+                "{}",
+                audio_buffer.write_cursor as i64 - audio_buffer.play_cursor as i64
+            );
         }
     }
 }

--- a/gba/src/main.rs
+++ b/gba/src/main.rs
@@ -7,28 +7,6 @@ use std::{env, fs::File, io::Read, time};
 use sdl2::audio::{AudioCallback, AudioSpecDesired};
 use sdl2::{event::Event, keyboard::Scancode, pixels::PixelFormatEnum};
 
-struct SquareWave {
-    phase_inc: f32,
-    phase: f32,
-    volume: f32,
-}
-
-impl AudioCallback for SquareWave {
-    type Channel = f32;
-
-    fn callback(&mut self, out: &mut [f32]) {
-        // Generate a square wave
-        for x in out.iter_mut() {
-            *x = if self.phase <= 0.5 {
-                self.volume
-            } else {
-                -self.volume
-            };
-            self.phase = (self.phase + self.phase_inc) % 1.0;
-        }
-    }
-}
-
 struct AudioBufferWrapper(Arc<Mutex<AudioRingBuffer>>);
 
 impl AudioCallback for AudioBufferWrapper {
@@ -40,13 +18,15 @@ impl AudioCallback for AudioBufferWrapper {
             let play_i = audio_buffer.play_cursor & (audio_buffer.buffer.len() - 1);
             *x = audio_buffer.buffer[play_i];
             audio_buffer.play_cursor += 1;
+            // TODO: Once CPU/APU sync is improved (namely: pipeline emulation), add some kind of desync compensation.
+            //
             // audio_buffer.play_cursor = (audio_buffer.play_cursor as i64
             //     + (((audio_buffer.write_cursor as i64 - audio_buffer.play_cursor as i64) >> 8)
             //         & !1)) as usize;
-            println!(
-                "{}",
-                audio_buffer.write_cursor as i64 - audio_buffer.play_cursor as i64
-            );
+            // println!(
+            //     "{}",
+            //     audio_buffer.write_cursor as i64 - audio_buffer.play_cursor as i64
+            // );
         }
     }
 }
@@ -103,13 +83,7 @@ fn main() {
     };
 
     let device = audio_subsystem
-        .open_playback(None, &desired_spec, |spec| {
-            // initialize the audio callback
-            // SquareWave {
-            //     phase_inc: 440.0 / spec.freq as f32,
-            //     phase: 0.0,
-            //     volume: 0.25,
-            // }
+        .open_playback(None, &desired_spec, |_spec| {
             AudioBufferWrapper(gba.get_audio_buffer())
         })
         .unwrap();

--- a/gba/src/main.rs
+++ b/gba/src/main.rs
@@ -2,6 +2,7 @@ use gba::GBA;
 use sound::AudioRingBuffer;
 
 use std::sync::{Arc, Mutex};
+use std::thread;
 use std::{env, fs::File, io::Read, time};
 
 use sdl2::audio::{AudioCallback, AudioSpecDesired};
@@ -16,7 +17,9 @@ impl AudioCallback for AudioBufferWrapper {
         let mut audio_buffer = self.0.lock().unwrap();
         for x in out.iter_mut() {
             let play_i = audio_buffer.play_cursor & (audio_buffer.buffer.len() - 1);
-            *x = audio_buffer.buffer[play_i];
+            // Simple volume attenuation in lieu of a volume setting
+            const VOL_MULTIPLIER: f32 = 0.25;
+            *x = audio_buffer.buffer[play_i] * VOL_MULTIPLIER;
             audio_buffer.play_cursor += 1;
             // TODO: Once CPU/APU sync is improved (namely: pipeline emulation), add some kind of desync compensation.
             //
@@ -46,7 +49,8 @@ fn main() {
         .build()
         .unwrap();
 
-    let mut canvas = window.into_canvas().present_vsync().build().unwrap();
+    // let mut canvas = window.into_canvas().present_vsync().build().unwrap();
+    let mut canvas = window.into_canvas().build().unwrap();
     let mut event_pump = sdl_context.event_pump().unwrap();
     canvas.set_scale(3.0, 3.0).unwrap();
 
@@ -134,7 +138,7 @@ fn main() {
 
             let elapsed = fps_timer.elapsed();
             if elapsed < time::Duration::from_millis(16) {
-                // thread::sleep(time::Duration::from_millis(16) - elapsed);
+                thread::sleep(time::Duration::from_millis(16) - elapsed);
             }
             fps_timer = time::Instant::now();
 

--- a/ppu/src/bg.rs
+++ b/ppu/src/bg.rs
@@ -132,10 +132,11 @@ impl PPU {
             let flip_v = (map_entry >> 11) & 1 == 1;
             if full_palette_mode {
                 let data = self.vram.borrow_mut().read(
-                    0x4000 * self.bg_control_regs[bg_n].char_block() as usize
+                    (0x4000 * self.bg_control_regs[bg_n].char_block() as usize
                         + 64 * tile_n as usize
                         + (if flip_v { 7 - row } else { row }) * 8
-                        + (if flip_h { 7 - pixel_n } else { pixel_n }),
+                        + (if flip_h { 7 - pixel_n } else { pixel_n }))
+                        % 0x18000,
                 );
                 if data != 0 {
                     let color = self.palette_ram.borrow_mut().read_u16(2 * data as usize);
@@ -146,10 +147,11 @@ impl PPU {
                 let byte_n = pixel_n / 2;
                 let is_left = (pixel_n % 2) == 0;
                 let data = self.vram.borrow_mut().read(
-                    0x4000 * self.bg_control_regs[bg_n].char_block() as usize
+                    (0x4000 * self.bg_control_regs[bg_n].char_block() as usize
                         + 32 * tile_n as usize
                         + (if flip_v { 7 - row } else { row }) * 4
-                        + (if flip_h { 3 - byte_n } else { byte_n }),
+                        + (if flip_h { 3 - byte_n } else { byte_n }))
+                        % 0x18000,
                 );
                 let color_i = if is_left ^ flip_h {
                     data & 0b1111

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/sound/Cargo.toml
+++ b/sound/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 memory = { path = "../memory" }
+bitfield = "0.13.2"

--- a/sound/Cargo.toml
+++ b/sound/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sound"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+memory = { path = "../memory" }

--- a/sound/src/consts.rs
+++ b/sound/src/consts.rs
@@ -1,0 +1,9 @@
+pub const MASTER_CLOCK_HZ: u32 = 16_777_216;
+
+// The length counter is in units of 1/256 seconds, so this represents the number of clock ticks
+// per length counter decrement.
+pub const LENGTH_UNIT_PERIOD: u32 = MASTER_CLOCK_HZ / 256;
+// The envelope counter is in units of 1/64 seconds.
+pub const ENVELOPE_UNIT_PERIOD: u32 = MASTER_CLOCK_HZ / 64;
+// The sweep counter is in units of 1/64 seconds.
+pub const SWEEP_UNIT_PERIOD: u32 = MASTER_CLOCK_HZ / 128;

--- a/sound/src/dma_sound_channel.rs
+++ b/sound/src/dma_sound_channel.rs
@@ -1,0 +1,55 @@
+use std::collections::VecDeque;
+
+pub struct DmaSoundChannel {
+    fifo: VecDeque<u32>,
+    fifo_octet_i: usize,
+}
+
+impl DmaSoundChannel {
+    pub fn new() -> Self {
+        Self {
+            fifo: VecDeque::with_capacity(8),
+            fifo_octet_i: 0,
+        }
+    }
+
+    // Handles a write to one of the FIFO data registers. A write to the 0th octet pushes a new
+    // entry into the FIFO, while writes to the other offset simply overwrite octets in the most
+    // recent entry. I'm not sure if this is realistic, but I also don't think out-of-order writes
+    // to the 8-bit FIFO registers are well-defined.
+    pub fn write_fifo_octet(&mut self, octet_i: usize, data: u8) {
+        if octet_i == 0 {
+            self.fifo.push_back(0);
+        }
+        let fifo_entry = self.fifo.back_mut().unwrap();
+        let octet_offset = octet_i * 8;
+        let octet_mask = 0xFFu32 << octet_offset;
+        *fifo_entry &= !octet_mask;
+        *fifo_entry |= (data as u32) << octet_offset;
+    }
+
+    /// Returns true if a DMA is to be requested
+    pub fn tick_fifo(&mut self) -> bool {
+        if self.fifo_octet_i < 3 {
+            self.fifo_octet_i += 1;
+            false
+        } else {
+            self.fifo.pop_front();
+            self.fifo_octet_i = 0;
+            self.fifo.len() <= 4
+        }
+    }
+
+    pub fn restart(&mut self) {
+        self.fifo.clear();
+        self.fifo_octet_i = 0;
+    }
+
+    pub fn sample(&self) -> f32 {
+        if let Some(val) = self.fifo.front() {
+            ((val >> (self.fifo_octet_i * 8)) & 0xFF) as i8 as f32 / 128.
+        } else {
+            0.0
+        }
+    }
+}

--- a/sound/src/lib.rs
+++ b/sound/src/lib.rs
@@ -4,7 +4,10 @@ extern crate bitfield;
 mod registers;
 mod tone_channel;
 
-use tone_channel::*;
+pub use crate::registers::DmaSoundTimer;
+
+use crate::registers::*;
+use crate::tone_channel::*;
 
 use memory::Memory;
 
@@ -27,19 +30,66 @@ impl AudioRingBuffer {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum DmaSoundTimer {
-    Timer0,
-    Timer1,
+pub struct DmaSoundChannel {
+    fifo: VecDeque<u32>,
+    fifo_octet_i: usize,
+}
+
+impl DmaSoundChannel {
+    pub fn new() -> Self {
+        Self {
+            fifo: VecDeque::with_capacity(8),
+            fifo_octet_i: 0,
+        }
+    }
+
+    // Handles a write to one of the FIFO data registers. A write to the 0th octet pushes a new
+    // entry into the FIFO, while writes to the other offset simply overwrite octets in the most
+    // recent entry. I'm not sure if this is realistic, but I also don't think out-of-order writes
+    // to the 8-bit FIFO registers are well-defined.
+    pub fn write_fifo_octet(&mut self, octet_i: usize, data: u8) {
+        if octet_i == 0 {
+            self.fifo.push_back(0);
+        }
+        let fifo_entry = self.fifo.back_mut().unwrap();
+        let octet_offset = octet_i * 8;
+        let octet_mask = 0xFFu32 << octet_offset;
+        *fifo_entry &= !octet_mask;
+        *fifo_entry |= (data as u32) << octet_offset;
+    }
+
+    /// Returns true if a DMA is to be requested
+    pub fn tick_fifo(&mut self) -> bool {
+        if self.fifo_octet_i < 3 {
+            self.fifo_octet_i += 1;
+            false
+        } else {
+            self.fifo.pop_front();
+            self.fifo_octet_i = 0;
+            self.fifo.len() <= 4
+        }
+    }
+
+    pub fn sample(&self) -> f32 {
+        if let Some(val) = self.fifo.front() {
+            ((val >> (self.fifo_octet_i * 8)) & 0xFF) as i8 as f32 / 128.
+        } else {
+            0.0
+        }
+    }
+
+    fn restart(&mut self) {
+        self.fifo.clear();
+        self.fifo_octet_i = 0;
+    }
 }
 
 pub struct SoundController {
     // TODO: DO NOT SUBMIT: Temporary implementation
     tone_channels: [ToneChannel; 2],
+    dma_sound_channels: [DmaSoundChannel; 2],
+    dma_control_reg: DmaControlMixReg,
     sample_divider: u32,
-    fifos: [VecDeque<u32>; 2],
-    fifo_octet_i: [usize; 2],
-    dma_timer_select: [DmaSoundTimer; 2],
     request_dma: bool,
     audio_buffer: Arc<Mutex<AudioRingBuffer>>,
 }
@@ -48,10 +98,9 @@ impl SoundController {
     pub fn new(audio_buffer: Arc<Mutex<AudioRingBuffer>>) -> Self {
         Self {
             tone_channels: [ToneChannel::new(), ToneChannel::new()],
+            dma_sound_channels: [DmaSoundChannel::new(), DmaSoundChannel::new()],
+            dma_control_reg: DmaControlMixReg(0),
             sample_divider: 0,
-            fifos: [VecDeque::with_capacity(8), VecDeque::with_capacity(8)],
-            fifo_octet_i: [0; 2],
-            dma_timer_select: [DmaSoundTimer::Timer0; 2],
             request_dma: false,
             audio_buffer,
         }
@@ -72,17 +121,8 @@ impl SoundController {
             for tone_channel in &self.tone_channels {
                 audio_buffer.buffer[write_i] += 0.25 * tone_channel.sample();
             }
-            if self.fifos[0].len() > 0 {
-                audio_buffer.buffer[write_i] += ((self.fifos[0].front().unwrap()
-                    >> (self.fifo_octet_i[0] * 8))
-                    & 0xFF) as i8 as f32
-                    / 256.;
-            }
-            if self.fifos[1].len() > 0 {
-                audio_buffer.buffer[write_i] += ((self.fifos[1].front().unwrap()
-                    >> (self.fifo_octet_i[1] * 8))
-                    & 0xFF) as i8 as f32
-                    / 256.;
+            for dma_sound_channel in &self.dma_sound_channels {
+                audio_buffer.buffer[write_i] += 0.5 * dma_sound_channel.sample();
             }
             audio_buffer.write_cursor += 1;
         }
@@ -93,22 +133,11 @@ impl SoundController {
     }
 
     pub fn on_timer_overflow(&mut self, timer: DmaSoundTimer) {
-        for fifo_i in [0, 1] {
-            if self.dma_timer_select[fifo_i] == timer {
-                self.tick_fifo(fifo_i);
-            }
+        if self.dma_control_reg.dma_a_timer() == timer {
+            self.request_dma |= self.dma_sound_channels[0].tick_fifo();
         }
-    }
-
-    fn tick_fifo(&mut self, fifo_i: usize) {
-        if self.fifo_octet_i[fifo_i] < 3 {
-            self.fifo_octet_i[fifo_i] += 1;
-        } else {
-            self.fifos[fifo_i].pop_front();
-            self.fifo_octet_i[fifo_i] = 0;
-            if self.fifos[fifo_i].len() <= 4 {
-                self.request_dma = true;
-            }
+        if self.dma_control_reg.dma_b_timer() == timer {
+            self.request_dma |= self.dma_sound_channels[1].tick_fifo();
         }
     }
 }
@@ -132,35 +161,22 @@ impl Memory for SoundController {
             0x069 => self.tone_channels[0].control_reg.set_hi_byte(data),
             0x06C => self.tone_channels[0].set_frequency_reg_lo(data),
             0x06D => self.tone_channels[0].set_frequency_reg_hi(data),
+            0x082 => self.dma_control_reg.set_lo_byte(data),
             0x083 => {
-                self.dma_timer_select[0] = match (data >> 2) & 1 {
-                    0 => DmaSoundTimer::Timer0,
-                    1 | _ => DmaSoundTimer::Timer1,
-                };
-                self.dma_timer_select[1] = match (data >> 6) & 1 {
-                    0 => DmaSoundTimer::Timer0,
-                    1 | _ => DmaSoundTimer::Timer1,
-                };
-                if (data >> 3) & 1 == 1 {
-                    self.fifos[0].clear();
-                    self.fifo_octet_i[0] = 0;
+                self.dma_control_reg.set_hi_byte(data);
+                if self.dma_control_reg.dma_a_restart() {
+                    self.dma_sound_channels[0].restart();
                 }
-                if (data >> 7) & 1 == 1 {
-                    self.fifos[1].clear();
-                    self.fifo_octet_i[1] = 0;
+                if self.dma_control_reg.dma_b_restart() {
+                    self.dma_sound_channels[1].restart();
                 }
             }
             0x0A0..=0x0A7 => {
-                let reg_i = addr - 0x0A0;
-                let fifo_i = reg_i / 4;
-                if reg_i % 4 == 0 {
-                    self.fifos[fifo_i].push_back(0);
-                }
-                let fifo_entry = self.fifos[fifo_i].back_mut().unwrap();
-                let octet_offset = (reg_i as u32 % 4) * 8;
-                let octet_mask = 0xFFu32 << octet_offset;
-                *fifo_entry &= !octet_mask;
-                *fifo_entry |= (data as u32) << octet_offset;
+                let (fifo_i, octet_i) = {
+                    let reg_i = addr - 0x0A0;
+                    (reg_i / 4, reg_i % 4)
+                };
+                self.dma_sound_channels[fifo_i].write_fifo_octet(octet_i, data);
             }
             _ => {}
         }

--- a/sound/src/lib.rs
+++ b/sound/src/lib.rs
@@ -1,17 +1,18 @@
 #[macro_use]
 extern crate bitfield;
 
+mod dma_sound_channel;
 mod registers;
 mod tone_channel;
 
 pub use crate::registers::DmaSoundTimer;
 
+use crate::dma_sound_channel::*;
 use crate::registers::*;
 use crate::tone_channel::*;
 
 use memory::Memory;
 
-use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 pub struct AudioRingBuffer {
@@ -30,62 +31,7 @@ impl AudioRingBuffer {
     }
 }
 
-pub struct DmaSoundChannel {
-    fifo: VecDeque<u32>,
-    fifo_octet_i: usize,
-}
-
-impl DmaSoundChannel {
-    pub fn new() -> Self {
-        Self {
-            fifo: VecDeque::with_capacity(8),
-            fifo_octet_i: 0,
-        }
-    }
-
-    // Handles a write to one of the FIFO data registers. A write to the 0th octet pushes a new
-    // entry into the FIFO, while writes to the other offset simply overwrite octets in the most
-    // recent entry. I'm not sure if this is realistic, but I also don't think out-of-order writes
-    // to the 8-bit FIFO registers are well-defined.
-    pub fn write_fifo_octet(&mut self, octet_i: usize, data: u8) {
-        if octet_i == 0 {
-            self.fifo.push_back(0);
-        }
-        let fifo_entry = self.fifo.back_mut().unwrap();
-        let octet_offset = octet_i * 8;
-        let octet_mask = 0xFFu32 << octet_offset;
-        *fifo_entry &= !octet_mask;
-        *fifo_entry |= (data as u32) << octet_offset;
-    }
-
-    /// Returns true if a DMA is to be requested
-    pub fn tick_fifo(&mut self) -> bool {
-        if self.fifo_octet_i < 3 {
-            self.fifo_octet_i += 1;
-            false
-        } else {
-            self.fifo.pop_front();
-            self.fifo_octet_i = 0;
-            self.fifo.len() <= 4
-        }
-    }
-
-    pub fn sample(&self) -> f32 {
-        if let Some(val) = self.fifo.front() {
-            ((val >> (self.fifo_octet_i * 8)) & 0xFF) as i8 as f32 / 128.
-        } else {
-            0.0
-        }
-    }
-
-    fn restart(&mut self) {
-        self.fifo.clear();
-        self.fifo_octet_i = 0;
-    }
-}
-
 pub struct SoundController {
-    // TODO: DO NOT SUBMIT: Temporary implementation
     tone_channels: [ToneChannel; 2],
     dma_sound_channels: [DmaSoundChannel; 2],
     dma_control_reg: DmaControlMixReg,

--- a/sound/src/lib.rs
+++ b/sound/src/lib.rs
@@ -90,6 +90,7 @@ impl SoundController {
 
 impl Memory for SoundController {
     fn peek(&self, addr: usize) -> u8 {
+        // TODO: DO NOT SUBMIT: Implement reading
         match addr {
             _ => 0,
         }

--- a/sound/src/lib.rs
+++ b/sound/src/lib.rs
@@ -1,5 +1,6 @@
 use memory::Memory;
 
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 pub struct AudioRingBuffer {
@@ -11,11 +12,18 @@ pub struct AudioRingBuffer {
 impl AudioRingBuffer {
     pub fn new() -> Self {
         Self {
-            buffer: vec![0.0; 512 * 16 * 2],
+            // buffer: vec![0.0; 512 * 16 * 2],
+            buffer: vec![0.0; 512 * 16 * 8],
             write_cursor: 0,
             play_cursor: 0,
         }
     }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum DmaSoundTimer {
+    Timer0,
+    Timer1,
 }
 
 pub struct SoundController {
@@ -24,6 +32,10 @@ pub struct SoundController {
     tone2_counter: u32,
     tone2_period: u32,
     sample_divider: u32,
+    fifos: [VecDeque<u32>; 2],
+    fifo_octet_i: [usize; 2],
+    dma_timer_select: [DmaSoundTimer; 2],
+    request_dma: bool,
     audio_buffer: Arc<Mutex<AudioRingBuffer>>,
 }
 
@@ -34,11 +46,15 @@ impl SoundController {
             tone2_counter: 0,
             tone2_period: 262144,
             sample_divider: 0,
+            fifos: [VecDeque::with_capacity(8), VecDeque::with_capacity(8)],
+            fifo_octet_i: [0; 2],
+            dma_timer_select: [DmaSoundTimer::Timer0; 2],
+            request_dma: false,
             audio_buffer,
         }
     }
 
-    pub fn tick(&mut self) {
+    pub fn tick(&mut self) -> bool {
         if self.tone2_counter > 0 {
             self.tone2_counter -= 1;
         } else {
@@ -51,12 +67,51 @@ impl SoundController {
             self.sample_divider = 16_777_216 / 44_100;
             let mut audio_buffer = self.audio_buffer.lock().unwrap();
             let write_i = audio_buffer.write_cursor & (audio_buffer.buffer.len() - 1);
-            audio_buffer.buffer[write_i] = if self.tone2_counter < (self.tone2_period / 2) {
-                0.5
-            } else {
-                -0.5
-            };
+            audio_buffer.buffer[write_i] = 0.0;
+            // audio_buffer.buffer[write_i] += if self.tone2_counter < (self.tone2_period / 2) {
+            //     0.25
+            // } else {
+            //     -0.25
+            // };
+            if self.fifos[0].len() > 0 {
+                audio_buffer.buffer[write_i] += ((self.fifos[0].front().unwrap()
+                    >> (self.fifo_octet_i[0] * 8))
+                    & 0xFF) as i8 as f32
+                    / 256.;
+                // println!("{:?}", audio_buffer.buffer[write_i]);
+            }
+            if self.fifos[1].len() > 0 {
+                audio_buffer.buffer[write_i] += ((self.fifos[1].front().unwrap()
+                    >> (self.fifo_octet_i[1] * 8))
+                    & 0xFF) as i8 as f32
+                    / 256.;
+            }
             audio_buffer.write_cursor += 1;
+        }
+
+        let request_dma = self.request_dma;
+        self.request_dma = false;
+        request_dma
+    }
+
+    pub fn on_timer_overflow(&mut self, timer: DmaSoundTimer) {
+        for fifo_i in [0, 1] {
+            if self.dma_timer_select[fifo_i] == timer {
+                self.tick_fifo(fifo_i);
+            }
+        }
+    }
+
+    fn tick_fifo(&mut self, fifo_i: usize) {
+        // println!("Yee");
+        if self.fifo_octet_i[fifo_i] < 3 {
+            self.fifo_octet_i[fifo_i] += 1;
+        } else {
+            self.fifos[fifo_i].pop_front();
+            self.fifo_octet_i[fifo_i] = 0;
+            if self.fifos[fifo_i].len() <= 4 {
+                self.request_dma = true;
+            }
         }
     }
 }
@@ -79,6 +134,37 @@ impl Memory for SoundController {
                 self.tone2_rate &= 0x00FF;
                 self.tone2_rate |= (data as u16 & 0b111) << 8;
                 self.tone2_period = 16_777_216 / (131072 / (2048 - self.tone2_rate as u32));
+            }
+            0x083 => {
+                self.dma_timer_select[0] = match (data >> 2) & 1 {
+                    0 => DmaSoundTimer::Timer0,
+                    1 | _ => DmaSoundTimer::Timer1,
+                };
+                self.dma_timer_select[1] = match (data >> 6) & 1 {
+                    0 => DmaSoundTimer::Timer0,
+                    1 | _ => DmaSoundTimer::Timer1,
+                };
+                // println!("{:?}", self.dma_timer_select);
+                if (data >> 3) & 1 == 1 {
+                    self.fifos[0].clear();
+                    self.fifo_octet_i[0] = 0;
+                }
+                if (data >> 7) & 1 == 1 {
+                    self.fifos[1].clear();
+                    self.fifo_octet_i[1] = 0;
+                }
+            }
+            0x0A0..=0x0A7 => {
+                let reg_i = addr - 0x0A0;
+                let fifo_i = reg_i / 4;
+                if reg_i % 4 == 0 {
+                    self.fifos[fifo_i].push_back(0);
+                }
+                let fifo_entry = self.fifos[fifo_i].back_mut().unwrap();
+                let octet_offset = (reg_i as u32 % 4) * 8;
+                let octet_mask = 0xFFu32 << octet_offset;
+                *fifo_entry &= !octet_mask;
+                *fifo_entry |= (data as u32) << octet_offset;
             }
             _ => {}
         }

--- a/sound/src/lib.rs
+++ b/sound/src/lib.rs
@@ -1,0 +1,86 @@
+use memory::Memory;
+
+use std::sync::{Arc, Mutex};
+
+pub struct AudioRingBuffer {
+    pub buffer: Vec<f32>,
+    pub write_cursor: usize,
+    pub play_cursor: usize,
+}
+
+impl AudioRingBuffer {
+    pub fn new() -> Self {
+        Self {
+            buffer: vec![0.0; 512 * 16 * 2],
+            write_cursor: 0,
+            play_cursor: 0,
+        }
+    }
+}
+
+pub struct SoundController {
+    // TODO: DO NOT SUBMIT: Temporary implementation
+    tone2_rate: u16,
+    tone2_counter: u32,
+    tone2_period: u32,
+    sample_divider: u32,
+    audio_buffer: Arc<Mutex<AudioRingBuffer>>,
+}
+
+impl SoundController {
+    pub fn new(audio_buffer: Arc<Mutex<AudioRingBuffer>>) -> Self {
+        Self {
+            tone2_rate: 0,
+            tone2_counter: 0,
+            tone2_period: 262144,
+            sample_divider: 0,
+            audio_buffer,
+        }
+    }
+
+    pub fn tick(&mut self) {
+        if self.tone2_counter > 0 {
+            self.tone2_counter -= 1;
+        } else {
+            self.tone2_counter = self.tone2_period;
+        }
+
+        if self.sample_divider > 0 {
+            self.sample_divider -= 1;
+        } else {
+            self.sample_divider = 16_777_216 / 44_100;
+            let mut audio_buffer = self.audio_buffer.lock().unwrap();
+            let write_i = audio_buffer.write_cursor & (audio_buffer.buffer.len() - 1);
+            audio_buffer.buffer[write_i] = if self.tone2_counter < (self.tone2_period / 2) {
+                0.5
+            } else {
+                -0.5
+            };
+            audio_buffer.write_cursor += 1;
+        }
+    }
+}
+
+impl Memory for SoundController {
+    fn peek(&self, addr: usize) -> u8 {
+        match addr {
+            _ => 0,
+        }
+    }
+
+    fn write(&mut self, addr: usize, data: u8) {
+        match addr {
+            0x06C => {
+                self.tone2_rate &= 0xFF00;
+                self.tone2_rate |= data as u16;
+                self.tone2_period = 16_777_216 / (131072 / (2048 - self.tone2_rate as u32));
+            }
+            0x06D => {
+                self.tone2_rate &= 0x00FF;
+                self.tone2_rate |= (data as u16 & 0b111) << 8;
+                self.tone2_period = 16_777_216 / (131072 / (2048 - self.tone2_rate as u32));
+            }
+            _ => {}
+        }
+    }
+}

--- a/sound/src/lib.rs
+++ b/sound/src/lib.rs
@@ -3,6 +3,7 @@ extern crate bitfield;
 
 mod consts;
 mod dma_sound_channel;
+mod noise_channel;
 mod registers;
 mod tone_channel;
 mod wave_channel;
@@ -13,6 +14,7 @@ use crate::dma_sound_channel::*;
 use crate::registers::*;
 use crate::tone_channel::*;
 use crate::wave_channel::*;
+use crate::noise_channel::*;
 
 use memory::Memory;
 
@@ -37,6 +39,7 @@ impl AudioRingBuffer {
 pub struct SoundController {
     tone_channels: [ToneChannel; 2],
     wave_channel: WaveChannel,
+    noise_channel: NoiseChannel,
     dma_sound_channels: [DmaSoundChannel; 2],
     psg_left_right_reg: PsgLeftRightReg,
     dma_control_reg: DmaControlMixReg,
@@ -51,6 +54,7 @@ impl SoundController {
         Self {
             tone_channels: [ToneChannel::new(), ToneChannel::new()],
             wave_channel: WaveChannel::new(),
+            noise_channel: NoiseChannel::new(),
             dma_sound_channels: [DmaSoundChannel::new(), DmaSoundChannel::new()],
             psg_left_right_reg: PsgLeftRightReg(0),
             dma_control_reg: DmaControlMixReg(0),
@@ -67,6 +71,7 @@ impl SoundController {
         }
 
         self.wave_channel.tick();
+        self.noise_channel.tick();
 
         if self.sample_divider > 0 {
             self.sample_divider -= 1;
@@ -91,6 +96,12 @@ impl SoundController {
                 // TODO: Separate left and right audio
                 if wave_enabled.left || wave_enabled.right {
                     audio_buffer.buffer[write_i] += psg_multiplier * self.wave_channel.sample();
+                }
+
+                let noise_enabled = self.psg_left_right_reg.channel_enabled(3);
+                // TODO: Separate left and right audio
+                if noise_enabled.left || noise_enabled.right {
+                    audio_buffer.buffer[write_i] += psg_multiplier * self.noise_channel.sample();
                 }
 
                 for i in [0, 1] {
@@ -124,7 +135,6 @@ impl SoundController {
 
 impl Memory for SoundController {
     fn peek(&self, addr: usize) -> u8 {
-        // TODO: DO NOT SUBMIT: Implement reading
         match addr {
             0x060 => self.tone_channels[0].sweep_reg.lo_byte(),
             0x061 => self.tone_channels[0].sweep_reg.hi_byte(),
@@ -142,14 +152,18 @@ impl Memory for SoundController {
             0x073 => self.wave_channel.length_volume_reg.hi_byte(),
             0x074 => self.wave_channel.frequency_reg_lo(),
             0x075 => self.wave_channel.frequency_reg_hi(),
+            0x078 => self.noise_channel.control_reg_lo(),
+            0x079 => self.noise_channel.control_reg_hi(),
+            0x07C => self.noise_channel.frequency_reg_lo(),
+            0x07D => self.noise_channel.frequency_reg_hi(),
             0x080 => self.psg_left_right_reg.lo_byte(),
             0x081 => self.psg_left_right_reg.hi_byte(),
             0x082 => self.dma_control_reg.lo_byte(),
-            // TODO: DO NOT SUBMIT: Should the reset bit be masked out?
+            // TODO: Should the reset bit be masked out?
             0x083 => self.dma_control_reg.hi_byte(),
-            // TODO: DO NOT SUBMIT: Sound ON bits computed from channels
+            // TODO: Sound ON bits computed from channels
             0x084 => (self.master_enable as u8) << 7,
-            // TODO: DO NOT SUBMIT: 4000088h - SOUNDBIAS - Sound PWM Control
+            // TODO: 4000088h - SOUNDBIAS - Sound PWM Control
             0x090..=0x09F => {
                 let octet_i = addr - 0x090;
                 self.wave_channel.read_pattern_octet(octet_i)
@@ -176,6 +190,10 @@ impl Memory for SoundController {
             0x073 => self.wave_channel.length_volume_reg.set_hi_byte(data),
             0x074 => self.wave_channel.set_frequency_reg_lo(data),
             0x075 => self.wave_channel.set_frequency_reg_hi(data),
+            0x078 => self.noise_channel.set_control_reg_lo(data),
+            0x079 => self.noise_channel.set_control_reg_hi(data),
+            0x07C => self.noise_channel.set_frequency_reg_lo(data),
+            0x07D => self.noise_channel.set_frequency_reg_hi(data),
             0x080 => self.psg_left_right_reg.set_lo_byte(data),
             0x081 => self.psg_left_right_reg.set_hi_byte(data),
             0x082 => self.dma_control_reg.set_lo_byte(data),
@@ -189,7 +207,7 @@ impl Memory for SoundController {
                 }
             }
             0x084 => self.master_enable = (data >> 7) & 1 == 1,
-            // TODO: DO NOT SUBMIT: 4000088h - SOUNDBIAS - Sound PWM Control
+            // TODO: 4000088h - SOUNDBIAS - Sound PWM Control
             0x090..=0x09F => {
                 let octet_i = addr - 0x090;
                 self.wave_channel.write_pattern_octet(octet_i, data);

--- a/sound/src/lib.rs
+++ b/sound/src/lib.rs
@@ -90,7 +90,6 @@ impl SoundController {
                 let wave_enabled = self.psg_left_right_reg.channel_enabled(2);
                 // TODO: Separate left and right audio
                 if wave_enabled.left || wave_enabled.right {
-                    println!("{}", psg_multiplier * self.wave_channel.sample());
                     audio_buffer.buffer[write_i] += psg_multiplier * self.wave_channel.sample();
                 }
 
@@ -127,6 +126,34 @@ impl Memory for SoundController {
     fn peek(&self, addr: usize) -> u8 {
         // TODO: DO NOT SUBMIT: Implement reading
         match addr {
+            0x060 => self.tone_channels[0].sweep_reg.lo_byte(),
+            0x061 => self.tone_channels[0].sweep_reg.hi_byte(),
+            0x062 => self.tone_channels[0].control_reg_lo(),
+            0x063 => self.tone_channels[0].control_reg_hi(),
+            0x064 => self.tone_channels[0].frequency_reg_lo(),
+            0x065 => self.tone_channels[0].frequency_reg_hi(),
+            0x068 => self.tone_channels[1].control_reg_lo(),
+            0x069 => self.tone_channels[1].control_reg_hi(),
+            0x06C => self.tone_channels[1].frequency_reg_lo(),
+            0x06D => self.tone_channels[1].frequency_reg_hi(),
+            0x070 => self.wave_channel.control_reg.lo_byte(),
+            0x071 => self.wave_channel.control_reg.hi_byte(),
+            0x072 => self.wave_channel.length_volume_reg.lo_byte(),
+            0x073 => self.wave_channel.length_volume_reg.hi_byte(),
+            0x074 => self.wave_channel.frequency_reg_lo(),
+            0x075 => self.wave_channel.frequency_reg_hi(),
+            0x080 => self.psg_left_right_reg.lo_byte(),
+            0x081 => self.psg_left_right_reg.hi_byte(),
+            0x082 => self.dma_control_reg.lo_byte(),
+            // TODO: DO NOT SUBMIT: Should the reset bit be masked out?
+            0x083 => self.dma_control_reg.hi_byte(),
+            // TODO: DO NOT SUBMIT: Sound ON bits computed from channels
+            0x084 => (self.master_enable as u8) << 7,
+            // TODO: DO NOT SUBMIT: 4000088h - SOUNDBIAS - Sound PWM Control
+            0x090..=0x09F => {
+                let octet_i = addr - 0x090;
+                self.wave_channel.read_pattern_octet(octet_i)
+            }
             _ => 0,
         }
     }
@@ -162,6 +189,7 @@ impl Memory for SoundController {
                 }
             }
             0x084 => self.master_enable = (data >> 7) & 1 == 1,
+            // TODO: DO NOT SUBMIT: 4000088h - SOUNDBIAS - Sound PWM Control
             0x090..=0x09F => {
                 let octet_i = addr - 0x090;
                 self.wave_channel.write_pattern_octet(octet_i, data);

--- a/sound/src/lib.rs
+++ b/sound/src/lib.rs
@@ -63,6 +63,7 @@ impl SoundController {
             self.sample_divider = 16_777_216 / 44_100;
             let mut audio_buffer = self.audio_buffer.lock().unwrap();
             let write_i = audio_buffer.write_cursor & (audio_buffer.buffer.len() - 1);
+            // TODO: DO NOT SUBMIT: Channel enablement
             audio_buffer.buffer[write_i] = 0.0;
             for tone_channel in &self.tone_channels {
                 audio_buffer.buffer[write_i] += 0.25 * tone_channel.sample();

--- a/sound/src/noise_channel.rs
+++ b/sound/src/noise_channel.rs
@@ -1,0 +1,167 @@
+use crate::consts::*;
+use crate::registers::*;
+
+pub struct NoiseChannel {
+    control_reg: ToneControlReg,
+    frequency_reg: NoiseFrequencyReg,
+
+    counter: u32,
+    output_high: bool,
+    polynomial_shift_reg: u16,
+    curr_vol: u16,
+    length_counter: u32,
+    length_divider: u32,
+    envelope_counter: u32,
+    envelope_divider: u32,
+}
+
+impl NoiseChannel {
+    pub fn new() -> Self {
+        Self {
+            control_reg: ToneControlReg(0),
+            frequency_reg: NoiseFrequencyReg(0),
+
+            counter: 0,
+            output_high: false,
+            polynomial_shift_reg: 0,
+            curr_vol: 0,
+            length_counter: 0,
+            length_divider: 0,
+            envelope_counter: 0,
+            envelope_divider: 0,
+        }
+    }
+
+    // TODO: Deduplicate a lot of this from ToneChannel
+    pub fn tick(&mut self) {
+        self.tick_wave();
+        self.tick_length();
+        self.tick_envelope();
+    }
+
+    fn tick_wave(&mut self) {
+        if self.counter > 0 {
+            self.counter -= 1;
+        } else {
+            self.counter = self.period();
+            self.progress_playback();
+        }
+    }
+
+    fn progress_playback(&mut self) {
+        self.output_high = (self.polynomial_shift_reg & 1) == 1;
+        self.polynomial_shift_reg >>= 1;
+        if self.output_high {
+            self.polynomial_shift_reg ^= self.frequency_reg.shift_xor_factor();
+        }
+    }
+
+    fn tick_length(&mut self) {
+        if self.length_divider > 0 {
+            self.length_divider -= 1;
+        } else {
+            self.length_divider = LENGTH_UNIT_PERIOD;
+            if self.length_counter > 0 {
+                self.length_counter -= 1;
+            }
+        }
+    }
+
+    fn tick_envelope(&mut self) {
+        if self.envelope_divider > 0 {
+            self.envelope_divider -= 1;
+        } else {
+            self.envelope_divider = ENVELOPE_UNIT_PERIOD;
+            if self.envelope_counter > 0 {
+                self.envelope_counter -= 1;
+            } else {
+                self.envelope_counter = self.control_reg.envelope_step_time() as u32;
+                if self.envelope_counter == 0 {
+                    return;
+                }
+                self.curr_vol = match self.control_reg.envelope_dir() {
+                    EnvelopeDirection::Decrease => self.curr_vol.saturating_sub(1),
+                    EnvelopeDirection::Increase => std::cmp::min(self.curr_vol + 1, 15),
+                }
+            }
+        }
+    }
+
+    fn restart(&mut self) {
+        self.counter = self.period();
+        self.output_high = false;
+        self.polynomial_shift_reg = self.frequency_reg.shift_reg_init();
+        self.curr_vol = self.control_reg.envelope_init();
+        self.length_counter = 64 - self.control_reg.length() as u32;
+        self.length_divider = LENGTH_UNIT_PERIOD;
+        self.envelope_counter = self.control_reg.envelope_step_time() as u32;
+        self.envelope_divider = ENVELOPE_UNIT_PERIOD;
+    }
+
+    pub fn sample(&self) -> f32 {
+        if self.frequency_reg.timed() && self.length_counter == 0 {
+            return 0.0;
+        }
+        let vol = (self.curr_vol as f32) / 15.0;
+        if self.output_high {
+            vol
+        } else {
+            -vol
+        }
+    }
+
+    pub fn set_control_reg_lo(&mut self, data: u8) {
+        self.control_reg.set_lo_byte(data);
+    }
+
+    // TODO: Deduplicate some of this register read/write logic from ToneChannel
+    // Maybe by encapsulating the register and its computed attributes/callbacks in a struct?
+    pub fn set_control_reg_hi(&mut self, data: u8) {
+        self.control_reg.set_hi_byte(data);
+        // Writing zeroes to bits 3-7 of this half of the control register immediately turns off
+        // the channel.
+        if self.control_reg.envelope_dir() == EnvelopeDirection::Decrease
+            && self.control_reg.envelope_init() == 0
+        {
+            self.curr_vol = 0;
+        }
+    }
+
+    pub fn control_reg_lo(&self) -> u8 {
+        self.control_reg.lo_byte()
+    }
+
+    pub fn control_reg_hi(&self) -> u8 {
+        self.control_reg.hi_byte()
+    }
+
+    pub fn set_frequency_reg_lo(&mut self, data: u8) {
+        self.frequency_reg.set_lo_byte(data);
+    }
+
+    pub fn set_frequency_reg_hi(&mut self, data: u8) {
+        self.frequency_reg.set_hi_byte(data);
+        if self.frequency_reg.restart() {
+            self.restart();
+        }
+    }
+
+    pub fn frequency_reg_lo(&self) -> u8 {
+        self.frequency_reg.lo_byte()
+    }
+
+    pub fn frequency_reg_hi(&self) -> u8 {
+        self.frequency_reg.hi_byte()
+    }
+
+    fn period(&self) -> u32 {
+        const MULTIPLIER_HZ: u32 = 524_288;
+        let base_freq = match self.frequency_reg.divide_ratio() {
+            0 => MULTIPLIER_HZ * 2,
+            1 => MULTIPLIER_HZ,
+            2 | _ => MULTIPLIER_HZ / 2,
+        };
+        let factor = 1u32 << (self.frequency_reg.shift_frequency() + 1);
+        MASTER_CLOCK_HZ / (base_freq / factor)
+    }
+}

--- a/sound/src/registers.rs
+++ b/sound/src/registers.rs
@@ -1,10 +1,27 @@
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum SweepDirection {
+    Decrease,
+    Increase,
+}
+
+impl From<u8> for SweepDirection {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Increase,
+            1 | _ => Self::Decrease,
+        }
+    }
+}
+
 bitfield! {
   /// 4000060h - SOUND1CNT_L
   /// Configures tone sweep for channel 1
   pub struct ToneSweepReg(u16);
   impl Debug;
   pub sweep_shift_n, _: 2, 0;
-  pub sweep_dir, _: 3;
+  // bitfield ignores types and `into` for single-index fields, so `3, 3` tells it to treat it
+  // like a non-bool field.
+  pub u8, into SweepDirection, sweep_dir, _: 3, 3;
   pub sweep_time, _: 6, 4;
 
   pub u8, lo_byte, set_lo_byte: 7, 0;

--- a/sound/src/registers.rs
+++ b/sound/src/registers.rs
@@ -105,14 +105,32 @@ bitfield! {
   /// Controls frequency, length-limiting and resetting for channel 4
   pub struct NoiseFrequencyReg(u16);
   impl Debug;
-  pub rate, _: 2, 0;
+  pub divide_ratio, _: 2, 0;
   pub counter_step, _: 3;
   pub shift_frequency, _: 7, 4;
   pub timed, _: 14;
-  pub reset, _: 15;
+  pub restart, _: 15;
 
   pub u8, lo_byte, set_lo_byte: 7, 0;
   pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+impl NoiseFrequencyReg {
+    pub fn counter_width(&self) -> usize {
+        if self.counter_step() {
+            15
+        } else {
+            7
+        }
+    }
+
+    pub fn shift_reg_init(&self) -> u16 {
+        0x40 << (self.counter_width() - 7)
+    }
+
+    pub fn shift_xor_factor(&self) -> u16 {
+        0x60 << (self.counter_width() - 7)
+    }
 }
 
 pub struct LeftRight<T> {

--- a/sound/src/registers.rs
+++ b/sound/src/registers.rs
@@ -1,0 +1,150 @@
+bitfield! {
+  /// 4000060h - SOUND1CNT_L
+  /// Configures tone sweep for channel 1
+  pub struct ToneSweepReg(u16);
+  impl Debug;
+  pub sweep_shift_n, _: 2, 0;
+  pub sweep_dir, _: 3;
+  pub sweep_time, _: 6, 4;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+bitfield! {
+  /// 4000062h, 4000068h, 4000078h - SOUND1CNT_H, SOUND2CNT_L, SOUND4CNT_L
+  /// Configures duty, length and envelope for channels 1, 2 and 4
+  pub struct ToneControlReg(u16);
+  impl Debug;
+  pub length, _: 5, 0;
+  /// Ignored for channel 4 (noise)
+  pub duty_pattern, _: 7, 6;
+  pub envelope_step_time, _: 10, 8;
+  pub envelope_dir, _: 11;
+  pub envelope_init, _: 15, 12;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+bitfield! {
+  /// 4000064h, 400006Ch, 4000074h - SOUND1CNT_X, SOUND2CNT_H, SOUND3CNT_X
+  /// Controls frequency, length-limiting and resetting for channels 1, 2 and 3
+  pub struct FrequencyReg(u16);
+  impl Debug;
+  pub rate, _: 10, 0;
+  pub timed, _: 14;
+  pub reset, _: 15;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+bitfield! {
+  /// 4000070h - SOUND3CNT_L
+  /// Controls enablement and RAM selection for channel 3
+  pub struct WaveEnableReg(u16);
+  impl Debug;
+  pub ram_dimension, _: 5;
+  pub ram_bank_number, _: 6;
+  pub enable, _: 7;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+bitfield! {
+  /// 4000072h - SOUND3CNT_H
+  /// Controls length and volume for channel 3
+  pub struct WaveLengthVolumeReg(u16);
+  impl Debug;
+  pub length, _: 7, 0;
+  pub volume, _: 14, 13;
+  pub force_volume, _: 15;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+bitfield! {
+  /// 400007Ch - SOUND4CNT_H
+  /// Controls frequency, length-limiting and resetting for channel 4
+  pub struct NoiseFrequencyReg(u16);
+  impl Debug;
+  pub rate, _: 2, 0;
+  pub counter_step, _: 3;
+  pub shift_frequency, _: 7, 4;
+  pub timed, _: 14;
+  pub reset, _: 15;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+bitfield! {
+  /// 4000080h - SOUNDCNT_L
+  /// Controls L/R volume/enablement for channels 1-4 (PSG: Programmable Sound Generator)
+  pub struct PsgLeftRightReg(u16);
+  impl Debug;
+  pub vol_right, _: 2, 0;
+  pub vol_left, _: 6, 4;
+  pub enable_1_right, _: 8;
+  pub enable_2_right, _: 9;
+  pub enable_3_right, _: 10;
+  pub enable_4_right, _: 11;
+  pub enable_1_left, _: 12;
+  pub enable_2_left, _: 13;
+  pub enable_3_left, _: 14;
+  pub enable_4_left, _: 15;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+bitfield! {
+  /// 4000082h - SOUNDCNT_H
+  /// Configures DMA channel and sound mixing
+  pub struct DmaControlMixReg(u16);
+  impl Debug;
+  pub psg_vol, _: 1, 0;
+  pub dma_a_vol, _: 2;
+  pub dma_b_vol, _: 3;
+  pub enable_dma_a_right, _: 8;
+  pub enable_dma_a_left, _: 9;
+  pub dma_a_timer, _: 10;
+  pub dma_a_reset, _: 11;
+  pub enable_dma_b_right, _: 12;
+  pub enable_dma_b_left, _: 13;
+  pub dma_b_timer, _: 14;
+  pub dma_b_reset, _: 15;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+bitfield! {
+  /// 4000084h - SOUNDCNT_X
+  /// Controls and exposes whether channels are enabled/on
+  pub struct SoundOnReg(u16);
+  impl Debug;
+  pub psg_0_on, _: 0;
+  pub psg_1_on, _: 1;
+  pub psg_2_on, _: 2;
+  pub psg_3_on, _: 3;
+  pub master_enable, _: 7;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}
+
+bitfield! {
+  /// 4000088h - SOUNDBIAS
+  /// Controls sound bias and sample rate
+  pub struct SoundBiasReg(u16);
+  impl Debug;
+  pub bias, _: 9, 1;
+  pub sample_rate, _: 15, 14;
+
+  pub u8, lo_byte, set_lo_byte: 7, 0;
+  pub u8, hi_byte, set_hi_byte: 15, 8;
+}

--- a/sound/src/registers.rs
+++ b/sound/src/registers.rs
@@ -29,12 +29,12 @@ bitfield! {
 
 bitfield! {
   /// 4000064h, 400006Ch, 4000074h - SOUND1CNT_X, SOUND2CNT_H, SOUND3CNT_X
-  /// Controls frequency, length-limiting and resetting for channels 1, 2 and 3
+  /// Controls frequency, length-limiting and restarting for channels 1, 2 and 3
   pub struct FrequencyReg(u16);
   impl Debug;
   pub rate, _: 10, 0;
   pub timed, _: 14;
-  pub reset, _: 15;
+  pub restart, _: 15;
 
   pub u8, lo_byte, set_lo_byte: 7, 0;
   pub u8, hi_byte, set_hi_byte: 15, 8;

--- a/sound/src/registers.rs
+++ b/sound/src/registers.rs
@@ -77,10 +77,10 @@ bitfield! {
 bitfield! {
   /// 4000070h - SOUND3CNT_L
   /// Controls enablement and RAM selection for channel 3
-  pub struct WaveEnableReg(u16);
+  pub struct WaveControlReg(u16);
   impl Debug;
   pub ram_dimension, _: 5;
-  pub ram_bank_number, _: 6;
+  pub ram_bank_number, _: 6, 6;
   pub enable, _: 7;
 
   pub u8, lo_byte, set_lo_byte: 7, 0;

--- a/sound/src/registers.rs
+++ b/sound/src/registers.rs
@@ -101,6 +101,21 @@ bitfield! {
   pub u8, hi_byte, set_hi_byte: 15, 8;
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum DmaSoundTimer {
+    Timer0,
+    Timer1,
+}
+
+impl From<u8> for DmaSoundTimer {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Timer0,
+            1 | _ => Self::Timer1,
+        }
+    }
+}
+
 bitfield! {
   /// 4000082h - SOUNDCNT_H
   /// Configures DMA channel and sound mixing
@@ -111,12 +126,14 @@ bitfield! {
   pub dma_b_vol, _: 3;
   pub enable_dma_a_right, _: 8;
   pub enable_dma_a_left, _: 9;
-  pub dma_a_timer, _: 10;
-  pub dma_a_reset, _: 11;
+  // bitfield ignores types and `into` for single-index fields, so `10, 10` tells it to treat it
+  // like a non-bool field.
+  pub u8, into DmaSoundTimer, dma_a_timer, _: 10, 10;
+  pub dma_a_restart, _: 11;
   pub enable_dma_b_right, _: 12;
   pub enable_dma_b_left, _: 13;
-  pub dma_b_timer, _: 14;
-  pub dma_b_reset, _: 15;
+  pub u8, into DmaSoundTimer, dma_b_timer, _: 14, 14;
+  pub dma_b_restart, _: 15;
 
   pub u8, lo_byte, set_lo_byte: 7, 0;
   pub u8, hi_byte, set_hi_byte: 15, 8;

--- a/sound/src/registers.rs
+++ b/sound/src/registers.rs
@@ -11,6 +11,21 @@ bitfield! {
   pub u8, hi_byte, set_hi_byte: 15, 8;
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum EnvelopeDirection {
+    Decrease,
+    Increase,
+}
+
+impl From<u8> for EnvelopeDirection {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Decrease,
+            1 | _ => Self::Increase,
+        }
+    }
+}
+
 bitfield! {
   /// 4000062h, 4000068h, 4000078h - SOUND1CNT_H, SOUND2CNT_L, SOUND4CNT_L
   /// Configures duty, length and envelope for channels 1, 2 and 4
@@ -20,7 +35,9 @@ bitfield! {
   /// Ignored for channel 4 (noise)
   pub duty_pattern, _: 7, 6;
   pub envelope_step_time, _: 10, 8;
-  pub envelope_dir, _: 11;
+  // bitfield ignores types and `into` for single-index fields, so `11, 11` tells it to treat it
+  // like a non-bool field.
+  pub u8, into EnvelopeDirection, envelope_dir, _: 11, 11;
   pub envelope_init, _: 15, 12;
 
   pub u8, lo_byte, set_lo_byte: 7, 0;

--- a/sound/src/tone_channel.rs
+++ b/sound/src/tone_channel.rs
@@ -7,7 +7,7 @@ const LENGTH_UNIT_PERIOD: u32 = 16777216 / 256;
 pub struct ToneChannel {
     // Channel 2 doesn't support tone sweep, so this register is unmodifiable via IO for that channel.
     pub sweep_reg: ToneSweepReg,
-    pub control_reg: ToneControlReg,
+    control_reg: ToneControlReg,
     frequency_reg: FrequencyReg,
 
     counter: u32,
@@ -64,6 +64,19 @@ impl ToneChannel {
             vol
         } else {
             -vol
+        }
+    }
+
+    pub fn set_control_reg_lo(&mut self, data: u8) {
+        self.control_reg.set_lo_byte(data);
+    }
+
+    pub fn set_control_reg_hi(&mut self, data: u8) {
+        self.control_reg.set_hi_byte(data);
+        // Writing zeroes to bits 3-7 of this half of the control register immediately turns off
+        // the channel.
+        if !self.control_reg.envelope_dir() && self.control_reg.envelope_init() == 0 {
+            self.curr_vol = 0;
         }
     }
 

--- a/sound/src/tone_channel.rs
+++ b/sound/src/tone_channel.rs
@@ -112,7 +112,7 @@ impl ToneChannel {
         }
     }
 
-    pub fn restart(&mut self) {
+    fn restart(&mut self) {
         self.curr_rate = self.frequency_reg.rate();
         self.counter = self.period();
         self.curr_vol = self.control_reg.envelope_init();
@@ -125,7 +125,6 @@ impl ToneChannel {
     }
 
     pub fn sample(&self) -> f32 {
-        // TODO: DO NOT SUBMIT: Frequency sweep
         if self.frequency_reg.timed() && self.length_counter == 0 {
             return 0.0;
         }

--- a/sound/src/tone_channel.rs
+++ b/sound/src/tone_channel.rs
@@ -1,12 +1,5 @@
+use crate::consts::*;
 use crate::registers::*;
-
-// The length counter is in units of 1/256 seconds, so this represents the number of clock ticks
-// per length counter decrement.
-const LENGTH_UNIT_PERIOD: u32 = 16777216 / 256;
-// The envelope counter is in units of 1/64 seconds.
-const ENVELOPE_UNIT_PERIOD: u32 = 16777216 / 64;
-// The sweep counter is in units of 1/64 seconds.
-const SWEEP_UNIT_PERIOD: u32 = 16777216 / 128;
 
 pub struct ToneChannel {
     // Channel 2 doesn't support tone sweep, so this register is unmodifiable via IO for that channel.
@@ -163,7 +156,7 @@ impl ToneChannel {
     }
 
     fn period(&self) -> u32 {
-        16_777_216 / (131072 / (2048 - self.curr_rate as u32))
+        MASTER_CLOCK_HZ / (131_072 / (2048 - self.curr_rate as u32))
     }
 
     fn duty_high_width(&self) -> u32 {

--- a/sound/src/tone_channel.rs
+++ b/sound/src/tone_channel.rs
@@ -1,0 +1,66 @@
+use crate::registers::*;
+
+pub struct ToneChannel {
+    // Channel 2 doesn't support tone sweep, so this register is unmodifiable via IO for that channel.
+    pub sweep_reg: ToneSweepReg,
+    pub control_reg: ToneControlReg,
+    frequency_reg: FrequencyReg,
+
+    counter: u32,
+    period: u32,
+    curr_vol: u16,
+}
+
+impl ToneChannel {
+    pub fn new() -> Self {
+        Self {
+            sweep_reg: ToneSweepReg(0),
+            control_reg: ToneControlReg(0),
+            frequency_reg: FrequencyReg(0),
+
+            counter: 0,
+            period: 0,
+            curr_vol: 0,
+        }
+    }
+
+    pub fn tick(&mut self) {
+        if self.counter > 0 {
+            self.counter -= 1;
+        } else {
+            self.counter = self.period;
+        }
+    }
+
+    pub fn sample(&self) -> f32 {
+        // TODO: DO NOT SUBMIT: Duty cycle, etc.
+        let vol = (self.curr_vol as f32) / 15.0;
+        if self.counter < (self.period / 2) {
+            vol
+        } else {
+            -vol
+        }
+    }
+
+    pub fn set_frequency_reg_lo(&mut self, data: u8) {
+        self.frequency_reg.set_lo_byte(data);
+        self.update_period();
+    }
+
+    pub fn set_frequency_reg_hi(&mut self, data: u8) {
+        self.frequency_reg.set_hi_byte(data);
+        self.update_period();
+        if self.frequency_reg.restart() {
+            self.restart();
+        }
+    }
+
+    fn update_period(&mut self) {
+        self.period = 16_777_216 / (131072 / (2048 - self.frequency_reg.rate() as u32));
+    }
+
+    fn restart(&mut self) {
+        self.counter = self.period;
+        self.curr_vol = self.control_reg.envelope_init();
+    }
+}

--- a/sound/src/tone_channel.rs
+++ b/sound/src/tone_channel.rs
@@ -144,6 +144,14 @@ impl ToneChannel {
         }
     }
 
+    pub fn control_reg_lo(&self) -> u8 {
+        self.control_reg.lo_byte()
+    }
+
+    pub fn control_reg_hi(&self) -> u8 {
+        self.control_reg.hi_byte()
+    }
+
     pub fn set_frequency_reg_lo(&mut self, data: u8) {
         self.frequency_reg.set_lo_byte(data);
     }
@@ -153,6 +161,14 @@ impl ToneChannel {
         if self.frequency_reg.restart() {
             self.restart();
         }
+    }
+
+    pub fn frequency_reg_lo(&self) -> u8 {
+        self.frequency_reg.lo_byte()
+    }
+
+    pub fn frequency_reg_hi(&self) -> u8 {
+        self.frequency_reg.hi_byte()
     }
 
     fn period(&self) -> u32 {

--- a/sound/src/wave_channel.rs
+++ b/sound/src/wave_channel.rs
@@ -1,0 +1,145 @@
+use crate::consts::*;
+use crate::registers::*;
+
+pub struct WaveChannel {
+    pub control_reg: WaveControlReg,
+    pub length_volume_reg: WaveLengthVolumeReg,
+    frequency_reg: FrequencyReg,
+
+    // From MSB to LSB, the 128-bit integers store WAVE_RAM0, WAVE_RAM1, WAVE_RAM2, WAVE_RAM3.
+    // The most significant 4 bits are output at any given time, and the pattern is progressed by
+    // shifting the playing region (the non-selected bank in 32-digit mode, or the whole RAM in
+    // 64-digit mode) 4 bits to the left. This accords with the real hardware, where the pattern
+    // RAM is made up of 128-bit shift registers played in this same order.
+    pattern_ram: [u128; 2],
+    playing_octet: usize,
+    playing_other_bank: bool,
+    counter: u32,
+    length_counter: u32,
+    length_divider: u32,
+}
+
+impl WaveChannel {
+    pub fn new() -> Self {
+        Self {
+            control_reg: WaveControlReg(0),
+            length_volume_reg: WaveLengthVolumeReg(0),
+            frequency_reg: FrequencyReg(0),
+
+            pattern_ram: [0; 2],
+            playing_octet: 0,
+            playing_other_bank: false,
+            counter: 0,
+            length_counter: 0,
+            length_divider: 0,
+        }
+    }
+
+    pub fn sample(&self) -> f32 {
+        if !self.control_reg.enable() || (self.frequency_reg.timed() && self.length_counter == 0) {
+            return 0.0;
+        }
+        // TODO: DO NOT SUBMIT: How should this behave for e.g. all zeroes?
+        self.volume_multiplier()
+            * (((self.pattern_ram[self.playing_bank_i()] >> 124) as f32 / 15.0) - 0.5)
+    }
+
+    fn volume_multiplier(&self) -> f32 {
+        if self.length_volume_reg.force_volume() {
+            0.75
+        } else {
+            match self.length_volume_reg.volume() {
+                0 => 0.0,
+                1 => 1.0,
+                2 => 0.5,
+                3 | _ => 0.25,
+            }
+        }
+    }
+
+    fn playing_bank_i(&self) -> usize {
+        if self.control_reg.ram_dimension() && !self.playing_other_bank {
+            self.control_reg.ram_bank_number() as usize
+        } else {
+            1 - self.control_reg.ram_bank_number() as usize
+        }
+    }
+
+    pub fn tick(&mut self) {
+        if self.control_reg.enable() {
+            self.tick_wave();
+        }
+        self.tick_length();
+    }
+
+    // `octet_i` represents the i'th pattern RAM register (4000090h, 4000091h, 4000092h, etc.),
+    // although `pattern_ram` stores them in the opposite order.
+    pub fn read_pattern_octet(&mut self, octet_i: usize) -> u8 {
+        let bank_i = self.control_reg.ram_bank_number() as usize;
+        let offset = 8 * (7 - octet_i);
+        ((self.pattern_ram[bank_i] >> offset) & 0xFF) as u8
+    }
+
+    pub fn write_pattern_octet(&mut self, octet_i: usize, data: u8) {
+        let bank_i = self.control_reg.ram_bank_number() as usize;
+        let offset = 8 * (7 - octet_i);
+        self.pattern_ram[bank_i] &= !(0xFF << offset);
+        self.pattern_ram[bank_i] |= (data as u128) << offset;
+    }
+
+    fn tick_wave(&mut self) {
+        if self.counter > 0 {
+            self.counter -= 1;
+        } else {
+            self.counter = self.period();
+            self.progress_playback();
+        }
+    }
+
+    fn progress_playback(&mut self) {
+        let playing_bank_i = self.playing_bank_i();
+        self.pattern_ram[playing_bank_i] = self.pattern_ram[playing_bank_i].rotate_left(4);
+        if self.playing_octet < 7 {
+            self.playing_octet += 1;
+        } else {
+            self.playing_octet = 0;
+            if self.control_reg.ram_dimension() {
+                self.playing_other_bank = !self.playing_other_bank;
+            }
+        }
+    }
+
+    fn tick_length(&mut self) {
+        if self.length_divider > 0 {
+            self.length_divider -= 1;
+        } else {
+            self.length_divider = LENGTH_UNIT_PERIOD;
+            if self.length_counter > 0 {
+                self.length_counter -= 1;
+            }
+        }
+    }
+
+    pub fn set_frequency_reg_lo(&mut self, data: u8) {
+        self.frequency_reg.set_lo_byte(data);
+    }
+
+    pub fn set_frequency_reg_hi(&mut self, data: u8) {
+        self.frequency_reg.set_hi_byte(data);
+        if self.frequency_reg.restart() {
+            self.restart();
+        }
+    }
+
+    fn restart(&mut self) {
+        self.counter = self.period();
+        self.length_counter = 256 - self.length_volume_reg.length() as u32;
+        self.length_divider = LENGTH_UNIT_PERIOD;
+        self.playing_octet = 0;
+        self.playing_other_bank = false;
+    }
+
+    fn period(&self) -> u32 {
+        MASTER_CLOCK_HZ / (2_097_152 / (2048 - self.frequency_reg.rate() as u32))
+    }
+}

--- a/sound/src/wave_channel.rs
+++ b/sound/src/wave_channel.rs
@@ -74,7 +74,7 @@ impl WaveChannel {
 
     // `octet_i` represents the i'th pattern RAM register (4000090h, 4000091h, 4000092h, etc.),
     // although `pattern_ram` stores them in the opposite order.
-    pub fn read_pattern_octet(&mut self, octet_i: usize) -> u8 {
+    pub fn read_pattern_octet(&self, octet_i: usize) -> u8 {
         let bank_i = self.control_reg.ram_bank_number() as usize;
         let offset = 8 * (7 - octet_i);
         ((self.pattern_ram[bank_i] >> offset) & 0xFF) as u8
@@ -129,6 +129,14 @@ impl WaveChannel {
         if self.frequency_reg.restart() {
             self.restart();
         }
+    }
+
+    pub fn frequency_reg_lo(&self) -> u8 {
+        self.frequency_reg.lo_byte()
+    }
+
+    pub fn frequency_reg_hi(&self) -> u8 {
+        self.frequency_reg.hi_byte()
     }
 
     fn restart(&mut self) {

--- a/sound/src/wave_channel.rs
+++ b/sound/src/wave_channel.rs
@@ -39,7 +39,6 @@ impl WaveChannel {
         if !self.control_reg.enable() || (self.frequency_reg.timed() && self.length_counter == 0) {
             return 0.0;
         }
-        // TODO: DO NOT SUBMIT: How should this behave for e.g. all zeroes?
         self.volume_multiplier()
             * (((self.pattern_ram[self.playing_bank_i()] >> 124) as f32 / 15.0) - 0.5)
     }


### PR DESCRIPTION
This CL implements all the sound channels: two tone channels (one without frequency sweep), a wave channel, a noise channel, and two DMA sound channels. Slightly reworked timers and DMA channels to support the signaling pipeline for the DMA registers.

The logic for feeding sound to the frontend is slightly complex and slightly broken. The frontend and sound emulation have `Mutex` handles for a ring buffer containing sound data. When the sound card needs samples, it reads samples from the ring buffer using a playback cursor. Meanwhile, emulation produces samples at a rate based on the CPU frequency and the frontend sample rate. As long as emulation is running at ~60 FPS, this roughly synchronizes sample generation (driven by the emulated CPU clock) with the sample rate. There are several issues with this naive approach:

1) This only works if the frontend maintains 60 FPS.
2) Even with perfect emulation timing, the backend won't generate samples at exactly the right rate if emulation is clocked by VSync.
3) The presently imperfect CPU emulation (without an accurate pipeline) puts audio and emulation further out of sync.

Once (3) is fixed (thus improving the alignment of audio and frame generation timings), techniques will become feasible to address (1) and (2). Namely, the rate of sample generation can be adjusted based on the measured rate at which they're consumed, or vice-versa.